### PR TITLE
Remove focused and active state when item gets disconnected

### DIFF
--- a/test/vaadin-item-mixin.html
+++ b/test/vaadin-item-mixin.html
@@ -102,6 +102,13 @@
         expect(item.hasAttribute('active')).to.be.false;
       });
 
+      it('should not have active attribute when disconnected from the DOM', () => {
+        spaceDown(item);
+        item.remove();
+        window.ShadyDOM && window.ShadyDOM.flush();
+        expect(item.hasAttribute('active')).to.be.false;
+      });
+
       it('should not have focus-ring if not focused', () => {
         expect(item.hasAttribute('focus-ring')).to.be.false;
       });

--- a/vaadin-item-mixin.html
+++ b/vaadin-item-mixin.html
@@ -72,6 +72,17 @@ This program is available under Apache License Version 2.0, available at https:/
       this.addEventListener('keyup', e => this._onKeyup(e));
     }
 
+    disconnectedCallback() {
+      super.disconnectedCallback();
+
+      // in Firefox and Safari, blur does not fire on the element when it is removed,
+      // especially between keydown and keyup events, being active at the same time.
+      // reproducible in `<vaadin-dropdown-menu>` when closing overlay on select.
+      if (this.hasAttribute('active')) {
+        this._setFocused(false);
+      }
+    }
+
     _selectedChanged(selected) {
       this.setAttribute('aria-selected', selected);
     }


### PR DESCRIPTION
Connected to [vaadin/vaadin-dropdown-menu#44](https://github.com/vaadin/vaadin-dropdown-menu/issues/48)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-item/8)
<!-- Reviewable:end -->
