### PR TITLE
Update theme

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "polymer": "^2.0.0",
     "vaadin-themable-mixin": "^1.1.3",
-    "vaadin-valo-theme": "^2.0.0"
+    "vaadin-valo-styles": "vaadin/vaadin-valo-styles#^2.0.0"
   },
   "devDependencies": {
     "iron-test-helpers": "^2.0.0",

--- a/theme/valo/vaadin-item.html
+++ b/theme/valo/vaadin-item.html
@@ -1,8 +1,8 @@
-<link rel="import" href="../../../vaadin-valo-theme/font-icons.html">
-<link rel="import" href="../../../vaadin-valo-theme/sizing.html">
-<link rel="import" href="../../../vaadin-valo-theme/spacing.html">
-<link rel="import" href="../../../vaadin-valo-theme/style.html">
-<link rel="import" href="../../../vaadin-valo-theme/typography.html">
+<link rel="import" href="../../../vaadin-valo-styles/font-icons.html">
+<link rel="import" href="../../../vaadin-valo-styles/sizing.html">
+<link rel="import" href="../../../vaadin-valo-styles/spacing.html">
+<link rel="import" href="../../../vaadin-valo-styles/style.html">
+<link rel="import" href="../../../vaadin-valo-styles/typography.html">
 
 <dom-module id="valo-item" theme-for="vaadin-item">
   <template>

--- a/theme/valo/vaadin-item.html
+++ b/theme/valo/vaadin-item.html
@@ -10,21 +10,10 @@
       :host {
         display: flex;
         align-items: center;
-        min-height: var(--valo-size-m);
-        padding: var(--valo-space-xs) calc(var(--valo-space-m) + var(--valo-border-radius) / 4);
-        padding-right: calc(var(--valo-space-l) + var(--valo-border-radius) / 4);
         box-sizing: border-box;
         line-height: var(--valo-line-height-s);
         border-radius: var(--valo-border-radius);
         overflow: hidden;
-      }
-
-      @media (pointer: coarse) {
-        :host {
-          min-height: var(--valo-size-l);
-          padding-top: var(--valo-space-s);
-          padding-bottom: var(--valo-space-s);
-        }
       }
 
       /* It's the list-box's responsibility to add the focus style */


### PR DESCRIPTION
These styles were moved to the menu-overlay mixin in vaadin-valo-theme. They are only relevant for items inside the dropdown elements like dropdown-menu, context-menu and combo-box.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-item/12)
<!-- Reviewable:end -->
