### PR TITLE
Revert active state change causing tests to fail

### DIFF
--- a/analysis.json
+++ b/analysis.json
@@ -8,17 +8,17 @@
       "sourceRange": {
         "file": "src/vaadin-item.html",
         "start": {
-          "line": 48,
+          "line": 66,
           "column": 6
         },
         "end": {
-          "line": 48,
+          "line": 66,
           "column": 42
         }
       },
       "elements": [
         {
-          "description": "`<vaadin-item>` is a Polymer 2 element providing layout for items in tabs and menus.",
+          "description": "`<vaadin-item>` is a Polymer 2 element providing layout for items in tabs and menus.\n\n```\n  <vaadin-item>\n    Item content\n  </vaadin-item>\n```\n\n### Styling\n\nThe following state attributes are available for styling:\n\nAttribute  | Description | Part name\n-----------|-------------|------------\n`disabled` | Set to a disabled item | :host\n`focused` | Set when the element is focused | :host\n`focus-ring` | Set when the element is keyboard focused | :host\n`selected` | Set when the item is selected | :host\n`active` | Set when mousedown or enter/spacebar pressed | :host",
           "summary": "",
           "path": "src/vaadin-item.html",
           "properties": [
@@ -344,11 +344,11 @@
           "metadata": {},
           "sourceRange": {
             "start": {
-              "line": 33,
+              "line": 51,
               "column": 6
             },
             "end": {
-              "line": 41,
+              "line": 59,
               "column": 7
             }
           },

--- a/demo/item-basic-demos.html
+++ b/demo/item-basic-demos.html
@@ -20,6 +20,10 @@
           vaadin-item[focus-ring] {
             outline-color: purple;
           }
+
+          vaadin-item[active] {
+            background: #eee;
+          }
         </style>
         <vaadin-item tabindex="0">Foobar</vaadin-item>
       </template>

--- a/src/vaadin-item-mixin.html
+++ b/src/vaadin-item-mixin.html
@@ -132,8 +132,7 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     _setActive(active) {
-      // Only activate items which are focusable
-      if (active && this.hasAttribute('tabindex')) {
+      if (active) {
         this.setAttribute('active', '');
       } else {
         this.removeAttribute('active');

--- a/src/vaadin-item.html
+++ b/src/vaadin-item.html
@@ -27,6 +27,24 @@ This program is available under Apache License Version 2.0, available at https:/
       /**
        * `<vaadin-item>` is a Polymer 2 element providing layout for items in tabs and menus.
        *
+       * ```
+       *   <vaadin-item>
+       *     Item content
+       *   </vaadin-item>
+       * ```
+       *
+       * ### Styling
+       *
+       * The following state attributes are available for styling:
+       *
+       * Attribute  | Description | Part name
+       * -----------|-------------|------------
+       * `disabled` | Set to a disabled item | :host
+       * `focused` | Set when the element is focused | :host
+       * `focus-ring` | Set when the element is keyboard focused | :host
+       * `selected` | Set when the item is selected | :host
+       * `active` | Set when mousedown or enter/spacebar pressed | :host
+       *
        * @memberof Vaadin
        * @mixes Vaadin.ItemMixin
        * @mixes Vaadin.ThemableMixin


### PR DESCRIPTION
Fixes #15 

As discussed with @jouni, the change was questionable so let's just revert it for now.
Also added docs and demo for active state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-item/16)
<!-- Reviewable:end -->
