### PR TITLE
Set slotted iron-icon size

### DIFF
--- a/theme/lumo/vaadin-item.html
+++ b/theme/lumo/vaadin-item.html
@@ -59,6 +59,13 @@
         cursor: default;
         pointer-events: none;
       }
+
+      /* Slotted icons */
+
+      :host ::slotted(iron-icon) {
+        width: var(--lumo-icon-size-m);
+        height: var(--lumo-icon-size-m);
+      }
     </style>
   </template>
 </dom-module>


### PR DESCRIPTION
Similarly as is done for vaadin-button, vaadin-text-field and vaadin-tabs, so that the icons inside vaadin-item adapt to Lumo size settings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-item/21)
<!-- Reviewable:end -->
