### PR TITLE
Increase vertical padding

### DIFF
--- a/theme/lumo/vaadin-item.html
+++ b/theme/lumo/vaadin-item.html
@@ -14,7 +14,7 @@
         font-family: var(--lumo-font-family);
         font-size: var(--lumo-font-size-m);
         line-height: var(--lumo-line-height-xs);
-        padding: 0.25em 1em;
+        padding: 0.5em 1em;
         min-height: var(--lumo-size-m);
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
Allow a bit more white space for the item.

Visible, for example, when an item is taller than the height of vaadin-dropdown-menu-text-field (multiple lines of text).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-item/23)
<!-- Reviewable:end -->
