### PR TITLE
docs(api): move value JSDoc annotation to item [skip ci]

### DIFF
--- a/src/vaadin-item-mixin.html
+++ b/src/vaadin-item-mixin.html
@@ -54,16 +54,6 @@ This program is available under Apache License Version 2.0, available at https:/
       };
     }
 
-    constructor() {
-      super();
-
-      /**
-       * Submittable string value. The default value is the trimmed text content of the element.
-       * @type {string}
-       */
-      this.value;
-    }
-
     get value() {
       return this._value !== undefined ? this._value : this.textContent.trim();
     }

--- a/src/vaadin-item.html
+++ b/src/vaadin-item.html
@@ -72,6 +72,16 @@ This program is available under Apache License Version 2.0, available at https:/
         static get version() {
           return '2.1.0';
         }
+
+        constructor() {
+          super();
+
+          /**
+           * Submittable string value. The default value is the trimmed text content of the element.
+           * @type {string}
+           */
+          this.value;
+        }
       }
 
       customElements.define(ItemElement.is, ItemElement);


### PR DESCRIPTION
Fixes #41 

The root issue on the `polymer-analyzer` side is unlikely to be fixed any time soon.
So let's use this as a workaround to get the property documented:

## Before

![Screen Shot 2019-06-17 at 11 01 08](https://user-images.githubusercontent.com/10589913/59588050-62c26000-90ef-11e9-8084-703a08f772a4.png)

## After

![Screen Shot 2019-06-17 at 11 01 17](https://user-images.githubusercontent.com/10589913/59588060-67871400-90ef-11e9-80a8-d2ab935e60ee.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-item/49)
<!-- Reviewable:end -->
